### PR TITLE
fix: send signIn credentials as 'userNameOrEmail' and 'password' 

### DIFF
--- a/src/common/repositories/client.ts
+++ b/src/common/repositories/client.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const client = axios.create({
-  baseURL: "http://192.168.15.6:3000/api",
+  baseURL: "http://192.168.1.183:3000/api",
 });
 
 export default client;

--- a/src/common/repositories/signIn.repository.ts
+++ b/src/common/repositories/signIn.repository.ts
@@ -1,15 +1,15 @@
 import client from "./client";
 
 export interface signInDTO {
-  email: string;
+  usernameOrEmail: string;
   password: string;
 }
 
-export const signIn = async ({email, password}: signInDTO) => {
+export const signIn = async ({usernameOrEmail, password}: signInDTO) => {
   const {data} = await client.post<any>("/auth/signin", {
-    email,
+    usernameOrEmail,
     password,
   });
-  console.log("data", data);
+  console.log({data});
   return data;
 };

--- a/src/screens/signIn/models.ts
+++ b/src/screens/signIn/models.ts
@@ -1,10 +1,10 @@
 import signInSlice from "../../common/store/features/user/slices/signInSlice";
 
 export interface SignInViewModel {
-  email: string;
+  usernameOrEmail: string;
   password: string;
   setPassword: React.Dispatch<React.SetStateAction<string>>;
-  setEmail: React.Dispatch<React.SetStateAction<string>>;
+  setUsernameOrEmail: React.Dispatch<React.SetStateAction<string>>;
   signInState: ReturnType<typeof signInSlice>
   onSubmit: () => void;
   onClick: () => void;

--- a/src/screens/signIn/view.model.ts
+++ b/src/screens/signIn/view.model.ts
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import {useState} from "react";
 import {Alert} from "react-native";
 import {SignInViewModel} from "./models";
 import {useNavigation} from "@react-navigation/native";
@@ -16,12 +16,12 @@ const useSignInViewModel = (): SignInViewModel => {
 
   const signInState = useAppSelector((state) => state.signIn);
 
-  const [email, setEmail] = useState<string>("");
+  const [usernameOrEmail, setUsernameOrEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const onSubmit = async () => {
     try {
       dispatch(signInStart());
-      const response = await signIn({email, password});
+      const response = await signIn({usernameOrEmail, password});
       console.log("response", response);
       dispatch(signInSuccess(response));
     } catch (e: any) {
@@ -29,7 +29,7 @@ const useSignInViewModel = (): SignInViewModel => {
       dispatch(signInFailure(e.message || "Something went wrong"));
       Alert.alert("Oops!", "Something went wrong");
     } finally {
-      setEmail("");
+      setUsernameOrEmail("");
       setPassword("");
     }
   };
@@ -44,8 +44,8 @@ const useSignInViewModel = (): SignInViewModel => {
   };
 
   return {
-    email,
-    setEmail,
+    usernameOrEmail,
+    setUsernameOrEmail,
     password,
     setPassword,
     onSubmit,

--- a/src/screens/signIn/view.tsx
+++ b/src/screens/signIn/view.tsx
@@ -9,9 +9,9 @@ import LoadingView from "../../common/components/loading/view";
 
 const SignInView = () => {
   const {
-    email,
+    usernameOrEmail,
     password,
-    setEmail,
+    setUsernameOrEmail,
     setPassword,
     onSubmit,
     onClick,
@@ -32,8 +32,8 @@ const SignInView = () => {
               props={{
                 label: "E-mail",
                 placeholder: "type e-mail here",
-                value: email,
-                setValue: setEmail,
+                value: usernameOrEmail,
+                setValue: setUsernameOrEmail,
               }}
             />
             <TextInputView


### PR DESCRIPTION
Esse PR troca o objeto passado no login para `{ usernameOrEmail, password }`, para que o objeto esteja consistente com o que está sendo esperado no backend.

Ao desenvolver o backend, construí o service que atende essa rota de forma que tanto um username quanto um email possa ser passado. Assim, nomeei as credenciais de acordo.

Caso essa mudança não seja interessante de se fazer no mobile app, podemos modificar o backend para que o serviço leve em consideração apenas o e-mail do usuário, deixando o username disponível apenas para apresentação nos perfis e telas do aplicativo.